### PR TITLE
fix create.sh error because of missing frr/debian/rules

### DIFF
--- a/create.ini
+++ b/create.ini
@@ -60,7 +60,7 @@ VIRTUALENV=${HOME}/mypython
 # apt install ...
 #
 APT_MINS="make automake gcc virtualenv python-minimal python-dev openvswitch-switch"
-APT_PKGS="${APT_MINS} libtool wget dh-systemd dh-autoreconf"
+APT_PKGS="${APT_MINS} libtool wget dh-systemd dh-autoreconf devscripts"
 APT_PKGS="${APT_PKGS} unzip gawk pkg-config texinfo dejagnu bison flex"
 APT_PKGS="${APT_PKGS} python3-dev libjson-c-dev libpam0g-dev libc-ares-dev libreadline-dev"
 APT_PKGS="${APT_PKGS} libsystemd-dev libssl-dev libffi-dev libmnl-dev"
@@ -101,5 +101,7 @@ PROTOC_URL=https://github.com/google/protobuf/releases/download/v${PROTOC_VER}
 # FRR
 #
 FRR_URL=https://github.com/FRRouting/frr.git
-FRR_PKG=frr_3.0_amd64.deb
+FRR_PKG=frr_3.0-1~ubuntu16.04+1_amd64.deb
+FRR_TAR=frr_3.0-1~ubuntu16.04+1.debian.tar.xz
+FRR_ORG=frr_3.0.orig.tar.gz
 

--- a/create.sh
+++ b/create.sh
@@ -147,9 +147,20 @@ frr_pkg() {
         pushd $FRR_DIR
         git checkout -b 3.0 origin/stable/3.0
         patch -p1 < /tmp/frr.patch
+        ln -s debianpkg debian
     fi
 
     ./bootstrap.sh
+    ./configure
+    make dist
+    fakeroot debian/rules backports
+
+    cd ${LXD_WORK_DIR}
+    tar xvf ${FRR_DIR}/${FRR_ORG}
+    cd frr-*
+    . /etc/os-release
+    tar xvf ${FRR_DIR}/frr_*${ID}${VERSION_ID}*.debian.tar.xz
+
     fakeroot ./debian/rules binary
 
     popd


### PR DESCRIPTION
This PR fixes create.sh error because of missing frr/debian/rules.